### PR TITLE
Ignore permission errors

### DIFF
--- a/mounts.go
+++ b/mounts.go
@@ -55,8 +55,12 @@ func mounts() ([]Mount, error) {
 		var stat unix.Statfs_t
 		err := unix.Statfs(unescapeFstab(mountPoint), &stat)
 		if err != nil {
-			fmt.Printf("%s: %s\n", unescapeFstab(mountPoint), err)
-			continue
+			if err != os.ErrPermission {
+				fmt.Printf("%s: %s\n", mountPoint, err)
+				continue
+			}
+
+			stat = unix.Statfs_t{}
 		}
 
 		d := Mount{


### PR DESCRIPTION
duf should only print out unexpected errors. A missing permission is not unexpected.

Calling duf with the -all flag will still list these devices, albeit with missing size / space information.

Fixes #1.