### PR TITLE
Show or hide specific columns with --output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Sort the output:
 Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
 `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
 
+Show or hide specific columns:
+
+    duf --output mountpoint,size,usage
+
+Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
+`inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
+
 If you prefer your output as JSON:
 
     duf --json

--- a/mounts.go
+++ b/mounts.go
@@ -9,19 +9,19 @@ import (
 )
 
 type Mount struct {
-	Device      string        `json:"device"`
-	DeviceType  string        `json:"device_type"`
-	Mountpoint  string        `json:"mount_point"`
-	Fstype      string        `json:"fs_type"`
-	Type        string        `json:"type"`
-	Opts        string        `json:"opts"`
-	Total       uint64        `json:"total"`
-	Free        uint64        `json:"free"`
-	Used        uint64        `json:"used"`
-	InodesTotal uint64        `json:"inodes_total"`
-	InodesFree  uint64        `json:"inodes_free"`
-	InodesUsed  uint64        `json:"inodes_used"`
-	Stat        unix.Statfs_t `json:"-"`
+	Device     string        `json:"device"`
+	DeviceType string        `json:"device_type"`
+	Mountpoint string        `json:"mount_point"`
+	Fstype     string        `json:"fs_type"`
+	Type       string        `json:"type"`
+	Opts       string        `json:"opts"`
+	Total      uint64        `json:"total"`
+	Free       uint64        `json:"free"`
+	Used       uint64        `json:"used"`
+	Inodes     uint64        `json:"inodes"`
+	InodesFree uint64        `json:"inodes_free"`
+	InodesUsed uint64        `json:"inodes_used"`
+	Stat       unix.Statfs_t `json:"-"`
 }
 
 func readLines(filename string) ([]string, error) {

--- a/mounts_darwin.go
+++ b/mounts_darwin.go
@@ -67,18 +67,18 @@ func mounts() ([]Mount, []string, error) {
 		}
 
 		d := Mount{
-			Device:      device,
-			Mountpoint:  mountPoint,
-			Fstype:      fsType,
-			Type:        fsType,
-			Opts:        opts,
-			Stat:        stat,
-			Total:       (uint64(stat.Blocks) * uint64(stat.Bsize)),
-			Free:        (uint64(stat.Bavail) * uint64(stat.Bsize)),
-			Used:        (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(stat.Bsize),
-			InodesTotal: stat.Files,
-			InodesFree:  stat.Ffree,
-			InodesUsed:  stat.Files - stat.Ffree,
+			Device:     device,
+			Mountpoint: mountPoint,
+			Fstype:     fsType,
+			Type:       fsType,
+			Opts:       opts,
+			Stat:       stat,
+			Total:      (uint64(stat.Blocks) * uint64(stat.Bsize)),
+			Free:       (uint64(stat.Bavail) * uint64(stat.Bsize)),
+			Used:       (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(stat.Bsize),
+			Inodes:     stat.Files,
+			InodesFree: stat.Ffree,
+			InodesUsed: stat.Files - stat.Ffree,
 		}
 		d.DeviceType = deviceType(d)
 

--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -54,18 +54,18 @@ func mounts() ([]Mount, []string, error) {
 		}
 
 		d := Mount{
-			Device:      device,
-			Mountpoint:  mountPoint,
-			Fstype:      fstype,
-			Type:        fsTypeMap[int64(stat.Type)],
-			Opts:        mountOpts,
-			Stat:        stat,
-			Total:       (uint64(stat.Blocks) * uint64(stat.Bsize)),
-			Free:        (uint64(stat.Bavail) * uint64(stat.Bsize)),
-			Used:        (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(stat.Bsize),
-			InodesTotal: stat.Files,
-			InodesFree:  stat.Ffree,
-			InodesUsed:  stat.Files - stat.Ffree,
+			Device:     device,
+			Mountpoint: mountPoint,
+			Fstype:     fstype,
+			Type:       fsTypeMap[int64(stat.Type)],
+			Opts:       mountOpts,
+			Stat:       stat,
+			Total:      (uint64(stat.Blocks) * uint64(stat.Bsize)),
+			Free:       (uint64(stat.Bavail) * uint64(stat.Bsize)),
+			Used:       (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(stat.Bsize),
+			Inodes:     stat.Files,
+			InodesFree: stat.Ffree,
+			InodesUsed: stat.Files - stat.Ffree,
 		}
 		d.DeviceType = deviceType(d)
 

--- a/table.go
+++ b/table.go
@@ -10,7 +10,30 @@ import (
 	"github.com/muesli/termenv"
 )
 
+type Column struct {
+	ID        string
+	Name      string
+	SortIndex int
+	Width     int
+}
+
 var (
+	// "Mounted on", "Size", "Used", "Avail", "Use%", "Inodes", "Used", "Avail", "Use%", "Type", "Filesystem"
+	// mountpoint, size, used, avail, usage, inodes, inodes_used, inodes_avail, inodes_usage, type, filesystem
+	columns = []Column{
+		{ID: "mountpoint", Name: "Mounted on", SortIndex: 1},
+		{ID: "size", Name: "Size", SortIndex: 12, Width: 7},
+		{ID: "used", Name: "Used", SortIndex: 13, Width: 7},
+		{ID: "avail", Name: "Avail", SortIndex: 14, Width: 7},
+		{ID: "usage", Name: "Use%", SortIndex: 15, Width: 6},
+		{ID: "inodes", Name: "Inodes", SortIndex: 16, Width: 7},
+		{ID: "inodes_used", Name: "Used", SortIndex: 17, Width: 7},
+		{ID: "inodes_avail", Name: "Avail", SortIndex: 18, Width: 7},
+		{ID: "inodes_usage", Name: "Use%", SortIndex: 19, Width: 6},
+		{ID: "type", Name: "Type", SortIndex: 10},
+		{ID: "filesystem", Name: "Filesystem", SortIndex: 11},
+	}
+
 	colorRed     = term.Color("#E88388")
 	colorYellow  = term.Color("#DBAB79")
 	colorGreen   = term.Color("#A8CC8C")
@@ -19,6 +42,187 @@ var (
 	colorMagenta = term.Color("#D290E4")
 	colorCyan    = term.Color("#66C2CD")
 )
+
+func printTable(title string, m []Mount, sortBy int, cols []int) {
+	tab := table.NewWriter()
+	tab.SetAllowedRowLength(int(*width))
+	tab.SetOutputMirror(os.Stdout)
+	tab.SetStyle(table.StyleRounded)
+	tab.Style().Options.SeparateColumns = true
+
+	if barWidth() > 0 {
+		columns[4].Width = barWidth() + 7
+		columns[8].Width = barWidth() + 7
+	}
+	twidth := tableWidth(cols, tab.Style().Options.SeparateColumns)
+
+	tab.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 1, Hidden: !inColumns(cols, 1), WidthMax: int(float64(twidth) * 0.4)},
+		{Number: 2, Hidden: !inColumns(cols, 2), Transformer: sizeTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 3, Hidden: !inColumns(cols, 3), Transformer: sizeTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 4, Hidden: !inColumns(cols, 4), Transformer: spaceTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 5, Hidden: !inColumns(cols, 5), Transformer: barTransformer, AlignHeader: text.AlignCenter},
+		{Number: 6, Hidden: !inColumns(cols, 6), Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 7, Hidden: !inColumns(cols, 7), Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 8, Hidden: !inColumns(cols, 8), Align: text.AlignRight, AlignHeader: text.AlignRight},
+		{Number: 9, Hidden: !inColumns(cols, 9), Transformer: barTransformer, AlignHeader: text.AlignCenter},
+		{Number: 10, Hidden: !inColumns(cols, 10), WidthMax: int(float64(twidth) * 0.2)},
+		{Number: 11, Hidden: !inColumns(cols, 11), WidthMax: int(float64(twidth) * 0.4)},
+		{Number: 12, Hidden: true}, // sortBy helper for size
+		{Number: 13, Hidden: true}, // sortBy helper for used
+		{Number: 14, Hidden: true}, // sortBy helper for avail
+		{Number: 15, Hidden: true}, // sortBy helper for usage
+		{Number: 16, Hidden: true}, // sortBy helper for inodes size
+		{Number: 17, Hidden: true}, // sortBy helper for inodes used
+		{Number: 18, Hidden: true}, // sortBy helper for inodes avail
+		{Number: 19, Hidden: true}, // sortBy helper for inodes usage
+	})
+
+	headers := table.Row{}
+	for _, v := range columns {
+		headers = append(headers, v.Name)
+	}
+	tab.AppendHeader(headers)
+
+	for _, v := range m {
+		// spew.Dump(v)
+
+		var usage, inodeUsage float64
+		if v.Total > 0 {
+			usage = float64(v.Used) / float64(v.Total)
+		}
+		if v.Inodes > 0 {
+			inodeUsage = float64(v.InodesUsed) / float64(v.Inodes)
+		}
+
+		tab.AppendRow([]interface{}{
+			termenv.String(v.Mountpoint).Foreground(colorBlue), // mounted on
+			v.Total,      // size
+			v.Used,       // used
+			v.Free,       // avail
+			usage,        // use%
+			v.Inodes,     // inodes
+			v.InodesUsed, // inodes used
+			v.InodesFree, // inodes avail
+			inodeUsage,   // inodes use%
+			termenv.String(v.Fstype).Foreground(colorGray), // type
+			termenv.String(v.Device).Foreground(colorGray), // filesystem
+			v.Total,      // size sorting helper
+			v.Used,       // used sorting helper
+			v.Free,       // avail sorting helper
+			usage,        // use% sorting helper
+			v.Inodes,     // inodes sorting helper
+			v.InodesUsed, // inodes used sorting helper
+			v.InodesFree, // inodes avail sorting helper
+			inodeUsage,   // inodes use% sorting helper
+		})
+	}
+
+	if tab.Length() == 0 {
+		return
+	}
+
+	suffix := "device"
+	if tab.Length() > 1 {
+		suffix = "devices"
+	}
+	tab.SetTitle("%d %s %s", tab.Length(), title, suffix)
+
+	//tab.AppendFooter(table.Row{fmt.Sprintf("%d %s", tab.Length(), title)})
+	sortMode := table.Asc
+	if sortBy >= 12 {
+		sortMode = table.AscNumeric
+	}
+
+	tab.SortBy([]table.SortBy{{Number: sortBy, Mode: sortMode}})
+	tab.Render()
+}
+
+func sizeTransformer(val interface{}) string {
+	return sizeToString(val.(uint64))
+}
+
+func spaceTransformer(val interface{}) string {
+	free := val.(uint64)
+
+	var s = termenv.String(sizeToString(free))
+	switch {
+	case free < 1<<30:
+		s = s.Foreground(colorRed)
+	case free < 10*1<<30:
+		s = s.Foreground(colorYellow)
+	default:
+		s = s.Foreground(colorGreen)
+	}
+
+	return s.String()
+}
+
+func barTransformer(val interface{}) string {
+	usage := val.(float64)
+	s := termenv.String()
+	if usage > 0 {
+		if barWidth() > 0 {
+			bw := barWidth() - 2
+			s = termenv.String(fmt.Sprintf("[%s%s] %5.1f%%",
+				strings.Repeat("#", int(usage*float64(bw))),
+				strings.Repeat(".", bw-int(usage*float64(bw))),
+				usage*100,
+			))
+		} else {
+			s = termenv.String(fmt.Sprintf("%5.1f%%", usage*100))
+		}
+	}
+
+	// apply color to progress-bar
+	switch {
+	case usage >= 0.9:
+		s = s.Foreground(colorRed)
+	case usage >= 0.5:
+		s = s.Foreground(colorYellow)
+	default:
+		s = s.Foreground(colorGreen)
+	}
+
+	return s.String()
+}
+
+func inColumns(i []int, j int) bool {
+	for _, v := range i {
+		if v == j {
+			return true
+		}
+	}
+
+	return false
+}
+
+func barWidth() int {
+	switch {
+	case *width < 100:
+		return 0
+	case *width < 120:
+		return 12
+	default:
+		return 22
+	}
+}
+
+func tableWidth(cols []int, separators bool) int {
+	var sw int
+	if separators {
+		sw = 1
+	}
+
+	twidth := int(*width)
+	for i := 0; i < len(columns); i++ {
+		if inColumns(cols, i+1) {
+			twidth -= 2 + sw + columns[i].Width
+		}
+	}
+
+	return twidth
+}
 
 // sizeToString prettifies sizes.
 func sizeToString(size uint64) (str string) {
@@ -46,191 +250,35 @@ func sizeToString(size uint64) (str string) {
 
 // stringToColumn converts a column name to its index.
 func stringToColumn(s string) (int, error) {
-	switch strings.ToLower(s) {
-	case "mountpoint":
-		return 1, nil
-	case "size":
-		return 12, nil
-	case "used":
-		return 13, nil
-	case "avail":
-		return 14, nil
-	case "usage":
-		return 15, nil
-	case "inodes":
-		return 16, nil
-	case "inodes_used":
-		return 17, nil
-	case "inodes_avail":
-		return 18, nil
-	case "inodes_usage":
-		return 19, nil
-	case "type":
-		return 10, nil
-	case "filesystem":
-		return 11, nil
+	s = strings.ToLower(s)
 
-	default:
-		return 0, fmt.Errorf("unknown column identifier: %s", s)
-	}
-}
-
-func sizeTransformer(val interface{}) string {
-	return sizeToString(val.(uint64))
-}
-
-func spaceTransformer(val interface{}) string {
-	free := val.(uint64)
-
-	var s = termenv.String(sizeToString(free))
-	switch {
-	case free < 1<<30:
-		s = s.Foreground(colorRed)
-	case free < 10*1<<30:
-		s = s.Foreground(colorYellow)
-	default:
-		s = s.Foreground(colorGreen)
-	}
-
-	return s.String()
-}
-
-func barTransformer(val interface{}) string {
-	barWidth := 20
-	switch {
-	case *width < 100:
-		barWidth = 0
-	case *width < 120:
-		barWidth = 10
-	}
-
-	usage := val.(float64)
-	s := termenv.String()
-	if usage > 0 {
-		if barWidth > 0 {
-			s = termenv.String(fmt.Sprintf("[%s%s] %5.1f%%",
-				strings.Repeat("#", int(usage*float64(barWidth))),
-				strings.Repeat(".", barWidth-int(usage*float64(barWidth))),
-				usage*100,
-			))
-		} else {
-			s = termenv.String(fmt.Sprintf("%5.1f%%", usage*100))
+	for i, v := range columns {
+		if v.ID == s {
+			return i + 1, nil
 		}
 	}
 
-	// apply color to progress-bar
-	switch {
-	case usage >= 0.9:
-		s = s.Foreground(colorRed)
-	case usage >= 0.5:
-		s = s.Foreground(colorYellow)
-	default:
-		s = s.Foreground(colorGreen)
-	}
-
-	return s.String()
+	return 0, fmt.Errorf("unknown column: %s (valid: %s)", s, strings.Join(columnIDs(), ", "))
 }
 
-func printTable(title string, m []Mount, sortBy int, inodes bool) {
-	tab := table.NewWriter()
-	tab.SetAllowedRowLength(int(*width))
-	tab.SetOutputMirror(os.Stdout)
-	tab.SetStyle(table.StyleRounded)
-	// tab.Style().Options.SeparateColumns = false
+// stringToSortIndex converts a column name to its sort index.
+func stringToSortIndex(s string) (int, error) {
+	s = strings.ToLower(s)
 
-	barWidth := 20
-	switch {
-	case *width < 100:
-		barWidth = 0
-	case *width < 120:
-		barWidth = 10
-	}
-
-	cols := *width -
-		7*3 - // size columns
-		uint(barWidth) - // bar
-		6 - // percentage
-		2 - // frame
-		7*2 - // spacers
-		7 // seperators
-	if barWidth > 0 {
-		cols -= 2
-	}
-
-	tab.SetColumnConfigs([]table.ColumnConfig{
-		{Number: 1, WidthMax: int(float64(cols) * 0.4)},
-		{Number: 2, Hidden: inodes, Transformer: sizeTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 3, Hidden: inodes, Transformer: sizeTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 4, Hidden: inodes, Transformer: spaceTransformer, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 5, Hidden: inodes, Transformer: barTransformer, AlignHeader: text.AlignCenter},
-		{Number: 6, Hidden: !inodes, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 7, Hidden: !inodes, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 8, Hidden: !inodes, Align: text.AlignRight, AlignHeader: text.AlignRight},
-		{Number: 9, Hidden: !inodes, Transformer: barTransformer, AlignHeader: text.AlignCenter},
-		{Number: 10, WidthMax: int(float64(cols) * 0.2)},
-		{Number: 11, WidthMax: int(float64(cols) * 0.4)},
-		{Number: 12, Hidden: true}, // sortBy helper for size
-		{Number: 13, Hidden: true}, // sortBy helper for used
-		{Number: 14, Hidden: true}, // sortBy helper for avail
-		{Number: 15, Hidden: true}, // sortBy helper for usage
-		{Number: 16, Hidden: true}, // sortBy helper for inodes size
-		{Number: 17, Hidden: true}, // sortBy helper for inodes used
-		{Number: 18, Hidden: true}, // sortBy helper for inodes avail
-		{Number: 19, Hidden: true}, // sortBy helper for inodes usage
-	})
-
-	tab.AppendHeader(table.Row{"Mounted on", "Size", "Used", "Avail", "Use%", "Inodes", "Used", "Avail", "Use%", "Type", "Filesystem"})
-
-	for _, v := range m {
-		// spew.Dump(v)
-
-		var usage, inodeUsage float64
-		if v.Total > 0 {
-			usage = float64(v.Used) / float64(v.Total)
+	for _, v := range columns {
+		if v.ID == s {
+			return v.SortIndex, nil
 		}
-		if v.InodesTotal > 0 {
-			inodeUsage = float64(v.InodesUsed) / float64(v.InodesTotal)
-		}
-
-		tab.AppendRow([]interface{}{
-			termenv.String(v.Mountpoint).Foreground(colorBlue), // mounted on
-			v.Total,       // size
-			v.Used,        // used
-			v.Free,        // avail
-			usage,         // use%
-			v.InodesTotal, // size
-			v.InodesUsed,  // used
-			v.InodesFree,  // avail
-			inodeUsage,    // use%
-			termenv.String(v.Fstype).Foreground(colorGray), // type
-			termenv.String(v.Device).Foreground(colorGray), // filesystem
-			v.Total,       // size sorting helper
-			v.Used,        // used sorting helper
-			v.Free,        // avail sorting helper
-			usage,         // use% sorting helper
-			v.InodesTotal, // size sorting helper
-			v.InodesUsed,  // used sorting helper
-			v.InodesFree,  // avail sorting helper
-			inodeUsage,    // use% sorting helper
-		})
 	}
 
-	if tab.Length() == 0 {
-		return
+	return 0, fmt.Errorf("unknown column: %s (valid: %s)", s, strings.Join(columnIDs(), ", "))
+}
+
+func columnIDs() []string {
+	s := make([]string, len(columns))
+	for i, v := range columns {
+		s[i] = v.ID
 	}
 
-	suffix := "device"
-	if tab.Length() > 1 {
-		suffix = "devices"
-	}
-	tab.SetTitle("%d %s %s", tab.Length(), title, suffix)
-
-	//tab.AppendFooter(table.Row{fmt.Sprintf("%d %s", tab.Length(), title)})
-	sortMode := table.Asc
-	if sortBy >= 12 {
-		sortMode = table.AscNumeric
-	}
-
-	tab.SortBy([]table.SortBy{{Number: sortBy, Mode: sortMode}})
-	tab.Render()
+	return s
 }


### PR DESCRIPTION
Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`, `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.