### PR TITLE
Make duf a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.snap
 
 # Test binary, built with `go test -c`
 *.test

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,62 +4,11 @@ adopt-info: duf # Obtain version metadata from the 'duf' part
 license: MIT
 summary: Disk Usage/Free Utility
 description: |
-  ## Features
-  
-  - User-friendly, colorful output
-  - Adjusts to your terminal's width
-  - Sort the results according to your needs
-  - Groups & filters devices
-  - Can conveniently output JSON
+  duf is a user-friendly text-mode disk usage and free space utility. It
+  has colorful output and adjust to your text terminal's width. 
+  You can sort your results according to your needs. 
+  You can group together and filter your devices. Can output to JSON.
 
-  You can simply start duf without any command-line arguments:
-  
-  ```
-  duf
-  ```
-  
-  If you want to list everything (including pseudo, duplicate, inaccessible file systems):
-  
-  ```
-  duf --all
-  ```
-
-  You can hide individual tables:
-
-  ```
-  duf --hide-local --hide-network --hide-fuse --hide-special --hide-loops --hide-binds
-  ```
-
-  List inode information instead of block usage:
-
-  ```
-  duf --inodes
-  ```
-
-  Sort the output:
-
-  ```
-  duf --sort size
-  ```
-
-  Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
-  `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
-
-  Show or hide specific columns:
-
-  ```
-  duf --output mountpoint,size,usage
-  ```
-
-  Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
-  `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
-
-  If you prefer your output as JSON:
-
-  ```
-  duf --json
-  ```
-  
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,94 @@
+name: duf
+base: core18
+adopt-info: duf # Obtain version metadata from the 'duf' part
+license: MIT
+summary: Disk Usage/Free Utility
+description: |
+  ## Features
+  
+  - User-friendly, colorful output
+  - Adjusts to your terminal's width
+  - Sort the results according to your needs
+  - Groups & filters devices
+  - Can conveniently output JSON
+
+  You can simply start duf without any command-line arguments:
+  
+  ```
+  duf
+  ```
+  
+  If you want to list everything (including pseudo, duplicate, inaccessible file systems):
+  
+  ```
+  duf --all
+  ```
+
+  You can hide individual tables:
+
+  ```
+  duf --hide-local --hide-network --hide-fuse --hide-special --hide-loops --hide-binds
+  ```
+
+  List inode information instead of block usage:
+
+  ```
+  duf --inodes
+  ```
+
+  Sort the output:
+
+  ```
+  duf --sort size
+  ```
+
+  Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
+  `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
+
+  Show or hide specific columns:
+
+  ```
+  duf --output mountpoint,size,usage
+  ```
+
+  Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
+  `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
+
+  If you prefer your output as JSON:
+
+  ```
+  duf --json
+  ```
+  
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+parts:
+  license: # Include the license in the snap package
+    plugin: dump
+    source: https://github.com/muesli/duf.git
+    source-type: git
+    override-pull: | # Checkout the latest tag (=latest release)
+      snapcraftctl pull
+      VER=$(git describe --abbrev=0 --tags)
+      git checkout $VER
+    prime: 
+      - LICENSE
+
+  duf:
+    plugin: go
+    go-importpath: parts/duf
+    source: https://github.com/muesli/duf.git
+    source-type: git
+    override-pull: | # Checkout the latest tag (=latest release) and set the snap's version string
+      snapcraftctl pull
+      VER=$(git describe --abbrev=0 --tags)
+      git checkout $VER
+      snapcraftctl set-version $VER 
+    
+
+apps:
+  duf:
+    command: duf
+    plugs:
+      - mount-observe


### PR DESCRIPTION
This is an attempt to make `duf` a snap.
So far, it kind of works OK - no errors are thrown. But: The output of the regular binary and the snap are different, at least on my machine. Unfortunately, I don't have that much experience that I could solve that problem myself.
Maybe one of you people could help out?
Here are the two outputs:

<details><summary>Regular binary</summary>
<p>

```
philipp@laptop ~/P/S/duf ((v0.3.0))> ./duf 
/run/user/125/gvfs: permission denied
╭───────────────────────────────────────────────────────────────────────────────────────╮
│ 3 local devices                                                                       │
├──────────────────┬────────┬────────┬────────┬─────────────────────┬──────┬────────────┤
│ MOUNTED ON       │   SIZE │   USED │  AVAIL │         USE%        │ TYPE │ FILESYSTEM │
├──────────────────┼────────┼────────┼────────┼─────────────────────┼──────┼────────────┤
│ /                │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /home            │ 732.4G │ 546.1G │ 149.0G │ [#######...]  74.6% │ ext4 │ /dev/sda1  │
│ /run/timeshift/b │ 182.5G │  17.0G │ 156.2G │ [..........]   9.3% │ ext4 │ /dev/sda2  │
│ ackup            │        │        │        │                     │      │            │
╰──────────────────┴────────┴────────┴────────┴─────────────────────┴──────┴────────────╯
╭─────────────────────────────────────────────────────────────────────────────────────────╮
│ 8 special devices                                                                       │
├────────────────┬────────┬────────┬────────┬─────────────────────┬──────────┬────────────┤
│ MOUNTED ON     │   SIZE │   USED │  AVAIL │         USE%        │ TYPE     │ FILESYSTEM │
├────────────────┼────────┼────────┼────────┼─────────────────────┼──────────┼────────────┤
│ /dev           │   3.8G │     0B │   3.8G │                     │ devtmpfs │ udev       │
│ /dev/shm       │   3.8G │ 395.9M │   3.4G │ [#.........]  10.1% │ tmpfs    │ tmpfs      │
│ /run           │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ /run/lock      │   5.0M │   4.0K │   5.0M │ [..........]   0.1% │ tmpfs    │ tmpfs      │
│ /run/snapd/ns  │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ /run/user/1000 │ 783.8M │  80.0K │ 783.7M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ /run/user/125  │ 783.8M │  16.0K │ 783.8M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ /sys/fs/cgroup │   3.8G │     0B │   3.8G │                     │ tmpfs    │ tmpfs      │
╰────────────────┴────────┴────────┴────────┴─────────────────────┴──────────┴────────────╯

```

</p>
</details>

<details><summary>Snap</summary>
<p>

```
philipp@laptop ~/P/S/duf ((v0.3.0))> duf
/tmp/.mount_Nextclw6d1QD: no such file or directory
/var/lib/snapd/hostfs/run/user/125/gvfs: permission denied
/run/user/125/gvfs: permission denied
╭───────────────────────────────────────────────────────────────────────────────────────╮
│ 21 local devices                                                                      │
├──────────────────┬────────┬────────┬────────┬─────────────────────┬──────┬────────────┤
│ MOUNTED ON       │   SIZE │   USED │  AVAIL │         USE%        │ TYPE │ FILESYSTEM │
├──────────────────┼────────┼────────┼────────┼─────────────────────┼──────┼────────────┤
│ /etc             │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /home            │ 732.4G │ 546.1G │ 149.0G │ [#######...]  74.6% │ ext4 │ /dev/sda1  │
│ /lib/firmware    │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /lib/modules     │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /media           │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /mnt             │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /root            │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /run/timeshift/b │ 182.5G │  17.0G │ 156.2G │ [..........]   9.3% │ ext4 │ /dev/sda2  │
│ ackup            │        │        │        │                     │      │            │
│ /snap            │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /tmp             │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /tmp             │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /usr/lib/snapd   │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /usr/src         │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /var/lib/snapd   │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /var/lib/snapd/h │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ ostfs            │        │        │        │                     │      │            │
│ /var/lib/snapd/h │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ ostfs            │        │        │        │                     │      │            │
│ /var/lib/snapd/h │ 732.4G │ 546.1G │ 149.0G │ [#######...]  74.6% │ ext4 │ /dev/sda1  │
│ ostfs/home       │        │        │        │                     │      │            │
│ /var/lib/snapd/h │ 182.5G │  17.0G │ 156.2G │ [..........]   9.3% │ ext4 │ /dev/sda2  │
│ ostfs/run/timesh │        │        │        │                     │      │            │
│ ift/backup       │        │        │        │                     │      │            │
│ /var/log         │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /var/snap        │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
│ /var/tmp         │  63.7G │  26.1G │  34.2G │ [####......]  41.1% │ ext4 │ /dev/sdb1  │
╰──────────────────┴────────┴────────┴────────┴─────────────────────┴──────┴────────────╯
╭───────────────────────────────────────────────────────────────────────────────────────────╮
│ 18 special devices                                                                        │
├──────────────────┬────────┬────────┬────────┬─────────────────────┬──────────┬────────────┤
│ MOUNTED ON       │   SIZE │   USED │  AVAIL │         USE%        │ TYPE     │ FILESYSTEM │
├──────────────────┼────────┼────────┼────────┼─────────────────────┼──────────┼────────────┤
│ /dev             │   3.8G │     0B │   3.8G │                     │ devtmpfs │ udev       │
│ /dev/shm         │   3.8G │ 405.0M │   3.4G │ [#.........]  10.3% │ tmpfs    │ tmpfs      │
│ /run             │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ /run/lock        │   5.0M │   4.0K │   5.0M │ [..........]   0.1% │ tmpfs    │ tmpfs      │
│ /run/netns       │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ /run/snapd/ns    │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ /run/user/1000   │ 783.8M │  80.0K │ 783.7M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ /run/user/125    │ 783.8M │  16.0K │ 783.8M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ /sys/fs/cgroup   │   3.8G │     0B │   3.8G │                     │ tmpfs    │ tmpfs      │
│ /var/lib/snapd/h │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ ostfs/run        │        │        │        │                     │          │            │
│ /var/lib/snapd/h │   5.0M │   4.0K │   5.0M │ [..........]   0.1% │ tmpfs    │ tmpfs      │
│ ostfs/run/lock   │        │        │        │                     │          │            │
│ /var/lib/snapd/h │ 783.8M │   2.3M │ 781.5M │ [..........]   0.3% │ tmpfs    │ tmpfs      │
│ ostfs/run/snapd/ │        │        │        │                     │          │            │
│ ns               │        │        │        │                     │          │            │
│ /var/lib/snapd/h │ 783.8M │  80.0K │ 783.7M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ ostfs/run/user/1 │        │        │        │                     │          │            │
│ 000              │        │        │        │                     │          │            │
│ /var/lib/snapd/h │ 783.8M │  16.0K │ 783.8M │ [..........]   0.0% │ tmpfs    │ tmpfs      │
│ ostfs/run/user/1 │        │        │        │                     │          │            │
│ 25               │        │        │        │                     │          │            │
│ /var/lib/snapd/l │   3.8G │     0B │   3.8G │                     │ tmpfs    │ none       │
│ ib/gl            │        │        │        │                     │          │            │
│ /var/lib/snapd/l │   3.8G │     0B │   3.8G │                     │ tmpfs    │ none       │
│ ib/gl32          │        │        │        │                     │          │            │
│ /var/lib/snapd/l │   3.8G │     0B │   3.8G │                     │ tmpfs    │ none       │
│ ib/glvnd         │        │        │        │                     │          │            │
│ /var/lib/snapd/l │   3.8G │     0B │   3.8G │                     │ tmpfs    │ none       │
│ ib/vulkan        │        │        │        │                     │          │            │
╰──────────────────┴────────┴────────┴────────┴─────────────────────┴──────────┴────────────╯

```

</p>
</details>