### PR TITLE
Bump checkout version in build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Download Go modules
         run: go mod download


### PR DESCRIPTION
The Github Actions checkout got bumped to version 2.
Please **DO NOT MERGE** this PR until you decided on #25, since there will maybe be another checkout command where I would have to adjust the version number as well.