### PR TITLE
Update brew install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Disk Usage/Free Utility (Linux, BSD & macOS)
 
 - Arch Linux: [duf](https://aur.archlinux.org/packages/duf/)
 - macOS: 
-  - with [HomeBrew](https://brew.sh/): `brew install muesli/homebrew-tap/duf`
+  - with [HomeBrew](https://brew.sh/): `brew install duf`
   - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
 - Nix: `nix-env -iA nixpkgs.duf`
 - [Packages](https://github.com/muesli/duf/releases) in Debian & RPM formats


### PR DESCRIPTION
Trying to install `duf` with `brew install muesli/homebrew-tap/duf` failed:
```
~ brew install muesli/homebrew-tap/duf
[...]
==> Tapping muesli/tap
[...]
Error: No available formula or cask with the name "muesli/homebrew-tap/duf".
==> Searching for similarly named formulae...
This similarly named formula was found:
duf
To install it, run:
  brew install duf
```

Update brew section to include `brew install duf`