### PR TITLE
Update for Homebrew on Linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,8 +57,7 @@ nfpms:
     bindir: /usr/bin
 
 brews:
-  - ids:
-      - darwin
+-
     goarm: 6
     tap:
       owner: muesli


### PR DESCRIPTION
A small modification to get this working in Homebrew on Linux machines.

Testing on my local Ubuntu 18.04.5 machine shows reasonable output:
```
$ goreleaser --snapshot --skip-publish --skip-sign --rm-dist
$ cat dist/duf.rb 
# This file was generated by GoReleaser. DO NOT EDIT.
class Duf < Formula
  desc "Disk Usage/Free Utility"
  homepage "https://fribbledom.com/"
  version "v0.3.1-next"
  bottle :unneeded

  if OS.mac?
    url "https://github.com/seththeriault/duf/releases/download/v0.3.1/duf_v0.3.1-next_Darwin_x86_64.tar.gz"
    sha256 "d250e5e3892c0df3e56979bbb8140a63d6d264d6e55a05e148e322aaf5b5f0b1"
  elsif OS.linux?
    if Hardware::CPU.intel?
      url "https://github.com/seththeriault/duf/releases/download/v0.3.1/duf_v0.3.1-next_linux_x86_64.tar.gz"
      sha256 "ed692006a9896a0087090d62c3f359c7b9adfa145de50f70150962d1f88d7574"
    end
    if Hardware::CPU.arm?
      if Hardware::CPU.is_64_bit?
        url "https://github.com/seththeriault/duf/releases/download/v0.3.1/duf_v0.3.1-next_linux_arm64.tar.gz"
        sha256 "54554e7346d68d302fd5629aaaf409b5902ac33ce4cd029ab277653da91cfebb"
      else
        url "https://github.com/seththeriault/duf/releases/download/v0.3.1/duf_v0.3.1-next_linux_armv6.tar.gz"
        sha256 "a4a6a4f954b4fbe898c198dc94a7d14c60495d1e02e9da73dc1be8168ffe0814"
      end
    end
  end

  def install
    bin.install "duf"
  end
end
```

I know from testing for my previous (failed) attempt in muesli/homebrew-tap/pull/1 that the Homebrew formula should work.