### PR TITLE
Update macOS installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Disk Usage/Free Utility (Linux, BSD & macOS)
 
 - Arch Linux: [duf](https://aur.archlinux.org/packages/duf/)
 - macOS:
-  - with [Homebrew](https://brew.sh/): `brew install muesli/tap/duf`
+  - with [Homebrew](https://brew.sh/): `brew install duf`
   - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
 - Nix: `nix-env -iA nixpkgs.duf`
 - [Packages](https://github.com/muesli/duf/releases) in Debian & RPM formats


### PR DESCRIPTION
Hello! Current homebrew command `brew install muesli/tap/duf` is not working.
```
Error: No available formula or cask with the name "muesli/tap/duf".
==> Searching for similarly named formulae...
This similarly named formula was found:
duf
To install it, run:
  brew install duf
```

I've fixed it.