### PR TITLE
Fixed macOS installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Disk Usage/Free Utility (Linux, BSD & macOS)
 
 #### macOS
 - macOS:
-  - with [Homebrew](https://brew.sh/): `brew install muesli/tap/duf`
+  - with [Homebrew](https://brew.sh/): `brew tap muesli/tap; brew install duf`
   - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
 
 #### Android


### PR DESCRIPTION
Addresses #50 

Output:
```
$ brew tap muesli/tap; brew install duf
==> Tapping muesli/tap
Cloning into '/usr/local/Homebrew/Library/Taps/muesli/homebrew-tap'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 24 (delta 9), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (24/24), done.
Tapped 4 formulae (49 files, 29.8KB).
==> Installing duf from muesli/tap
==> Downloading https://github.com/muesli/duf/releases/download/v0.3.1/duf_0.3.1_Darwin_x86_64.tar.gz
Already downloaded: /Users/hem/Library/Caches/Homebrew/downloads/ceb7f19f422dc77f54a8450757f8623f28d1203021fa5245614840c90f2da998--duf_0.3.1_Darwin_x86_64.tar.gz
🍺  /usr/local/Cellar/duf/0.3.1: 5 files, 2.5MB, built in 6 seconds
```