### PR TITLE
Use EnvColorProfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ var (
 	Version   = ""
 	CommitSHA = ""
 
-	term  = termenv.ColorProfile()
+	term  = termenv.EnvColorProfile()
 	theme Theme
 
 	all         = flag.Bool("all", false, "include pseudo, duplicate, inaccessible file systems")


### PR DESCRIPTION
This change provides a way to enable colors (#11) via environment variable `CLICOLOR_FORCE=1`, as well as respects other env vars (described [here](https://github.com/muesli/termenv/pull/11)).