### PR TITLE
Hide overlay/shm filesystems per default

### DIFF
--- a/filesystems_darwin.go
+++ b/filesystems_darwin.go
@@ -15,3 +15,7 @@ func isNetworkFs(m Mount) bool {
 func isSpecialFs(m Mount) bool {
 	return m.Fstype == "devfs"
 }
+
+func isHiddenFs(m Mount) bool {
+	return false
+}

--- a/filesystems_freebsd.go
+++ b/filesystems_freebsd.go
@@ -30,3 +30,7 @@ func isSpecialFs(m Mount) bool {
 
 	return false
 }
+
+func isHiddenFs(m Mount) bool {
+	return false
+}

--- a/filesystems_linux.go
+++ b/filesystems_linux.go
@@ -266,3 +266,14 @@ func isNetworkFs(m Mount) bool {
 func isSpecialFs(m Mount) bool {
 	return specialMap[int64(m.Stat().Type)]
 }
+
+func isHiddenFs(m Mount) bool {
+	switch m.Device {
+	case "shm":
+		return true
+	case "overlay":
+		return true
+	}
+
+	return m.Fstype == "autofs"
+}

--- a/filesystems_openbsd.go
+++ b/filesystems_openbsd.go
@@ -15,3 +15,7 @@ func isNetworkFs(m Mount) bool {
 func isSpecialFs(m Mount) bool {
 	return m.Fstype == "devfs"
 }
+
+func isHiddenFs(m Mount) bool {
+	return false
+}

--- a/filesystems_windows.go
+++ b/filesystems_windows.go
@@ -49,3 +49,7 @@ func isSpecialFs(m Mount) bool {
 	_, ok := windowsSandboxMountPoints[m.Mountpoint]
 	return ok
 }
+
+func isHiddenFs(m Mount) bool {
+	return false
+}

--- a/groups.go
+++ b/groups.go
@@ -42,8 +42,9 @@ func renderTables(m []Mount, filters FilterOptions, opts TableOptions) {
 				continue
 			}
 		}
-		// skip autofs
-		if v.Fstype == "autofs" {
+
+		// skip hidden devices
+		if isHiddenFs(v) && !*all {
 			continue
 		}
 


### PR DESCRIPTION
This also enables other platforms to hide certain devices per default, however currently there's only an implementation on Linux.

Calling duf with `--all` will still show hidden devices.