### PR TITLE
Add support for path arguments to filter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,29 +57,23 @@ You can simply start duf without any command-line arguments:
 
     duf
 
+If you supply arguments, duf will only list specific devices & mount points:
+
+    duf /home /some/file
+
 If you want to list everything (including pseudo, duplicate, inaccessible file systems):
 
     duf --all
 
-You can show only individual tables:
+You can show and hide specific tables:
 
     duf --only local,network,fuse,special,loops,binds
-
-You can also show only specific filesystems:
-
-    duf --only-fs tmpfs,vfat
-
-You can hide individual tables:
-
     duf --hide local,network,fuse,special,loops,binds
 
-You can also hide specific filesystems:
+You can also show and hide specific filesystems:
 
+    duf --only-fs tmpfs,vfat
     duf --hide-fs tmpfs,vfat
-
-List inode information instead of block usage:
-
-    duf --inodes
 
 Sort the output:
 
@@ -94,6 +88,10 @@ Show or hide specific columns:
 
 Valid keys are: `mountpoint`, `size`, `used`, `avail`, `usage`, `inodes`,
 `inodes_used`, `inodes_avail`, `inodes_usage`, `type`, `filesystem`.
+
+List inode information instead of block usage:
+
+    duf --inodes
 
 If duf doesn't detect your terminal's colors correctly, you can set a theme:
 

--- a/filesystems.go
+++ b/filesystems.go
@@ -1,5 +1,50 @@
 package main
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func findMounts(mounts []Mount, path string) ([]Mount, error) {
+	var err error
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var m []Mount
+	for _, v := range mounts {
+		if path == v.Device {
+			return []Mount{v}, nil
+		}
+
+		if strings.HasPrefix(path, v.Mountpoint) {
+			var nm []Mount
+
+			// keep all entries that are as close or closer to the target
+			for _, mv := range m {
+				if len(mv.Mountpoint) >= len(v.Mountpoint) {
+					nm = append(nm, mv)
+				}
+			}
+			m = nm
+
+			// add entry only if we didn't already find something closer
+			if len(nm) == 0 || len(v.Mountpoint) >= len(nm[0].Mountpoint) {
+				m = append(m, v)
+			}
+		}
+	}
+
+	return m, nil
+}
+
 func deviceType(m Mount) string {
 	if isNetworkFs(m) {
 		return networkDevice


### PR DESCRIPTION
This means you can now call `duf` with a file, dir or device path, like:

```bash
duf /home /some/file
```

Fixes #78.