### PR TITLE
README: add instructions for installing via scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 - macOS:
   - with [Homebrew](https://brew.sh/): `brew tap muesli/tap && brew install duf`
   - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
+  
+
+#### Windows
+- Windows:
+  - with [scoop](https://scoop.sh/): `scoop install duf`
 
 #### Android
 - Android (via termux): `pkg install duf`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 - macOS:
   - with [Homebrew](https://brew.sh/): `brew tap muesli/tap && brew install duf`
   - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
-  
 
 #### Windows
 - Windows:


### PR DESCRIPTION
Now we could install `duf` via `scoop install duf` on Windows!

https://github.com/ScoopInstaller/Main/pull/1654