### PR TITLE
Ignore snaps by default on Linux

### DIFF
--- a/filesystems_linux.go
+++ b/filesystems_linux.go
@@ -2,6 +2,8 @@
 
 package main
 
+import "strings"
+
 const (
 	// man statfs
 	ADFS_SUPER_MAGIC      = 0xadf5
@@ -279,5 +281,14 @@ func isHiddenFs(m Mount) bool {
 		return true
 	}
 
-	return m.Fstype == "autofs"
+	switch m.Fstype {
+	case "autofs":
+		return true
+	case "squashfs":
+		if strings.HasPrefix(m.Mountpoint, "/snap") {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
snap mounts like 2-3 squashfs per installed snap (once per installed
version), so you easily end up with 53 mounted squashfs, which makes
the output hard to read.

Fixes #97