### PR TITLE
Build binary for ppc64le architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,7 @@ builds:
       - arm64
       - 386
       - arm
+      - ppc64le
     goarm:
       - 6
       - 7


### PR DESCRIPTION
The PowerPC 64 LE is quite popular amongst researchers and enterprise users. It would be awesome if the binary is also available for this platform.