### PR TITLE
Update README.md for MacOS X installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 - FreeBSD: `pkg install duf`
 
 #### macOS
-- with [Homebrew](https://brew.sh/): `brew install duf`
+- with [Homebrew](https://brew.sh/): `brew tap muesli/tap ; brew install duf`
 - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
 
 #### Windows


### PR DESCRIPTION
Adding the `brew tap` command, which was required (at least in my case) to install duf with brew.