### PR TITLE
Add FUSECTL_SUPER_MAGIC to special devices map

### DIFF
--- a/filesystems_linux.go
+++ b/filesystems_linux.go
@@ -242,6 +242,7 @@ var specialMap = map[int64]bool{
 	DEBUGFS_MAGIC:          true,
 	DEVPTS_SUPER_MAGIC:     true,
 	EFIVARFS_MAGIC:         true,
+	FUSECTL_SUPER_MAGIC:    true,
 	HUGETLBFS_MAGIC:        true,
 	MQUEUE_MAGIC:           true,
 	PROC_SUPER_MAGIC:       true,


### PR DESCRIPTION
This only shows up when launched with `--all`, but it still doesn't belong to the local devices table.