### PR TITLE
Use a classic confinement for snap builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,13 +69,9 @@ snapcrafts:
       Disk Usage/Free Utility
 
     grade: stable
-    confinement: strict
+    confinement: classic
     license: MIT
     base: core20
-
-    apps:
-      duf:
-        plugs: ["mount-observe"]
 
 signs:
   - artifacts: checksum


### PR DESCRIPTION
This gives us access to the real `mountinfo`, which duf needs to correctly parse the mounted devices.