### PR TITLE
Only login to snapcraft when secret is available in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,12 +15,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
       - name: Set up Snapcraft
-        env:
-          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
         run: |
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
-          snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
+      - name: Login Snapcraft
+        env:
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        if: env.SNAPCRAFT_LOGIN != null
+        run: snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
We need to skip this step, as it would fail for PRs, where the secret isn't available.