### PR TITLE
Add installation instructions for Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 #### Linux
 - Arch Linux: `pacman -S duf`
 - Nix: `nix-env -iA nixpkgs.duf`
+- Void Linux: `xbps-install -S duf`
 - Snap: `sudo snap install duf-utility` ([snapcraft.io](https://snapcraft.io/duf-utility))
 - [Packages](https://github.com/muesli/duf/releases) in Alpine, Debian & RPM formats
 


### PR DESCRIPTION
I was quite happy to find a very up-to-date `duf` in [`xbps`](https://github.com/void-linux/xbps), Void’s package manager! I've added installation instructions for Void accordingly.