### PR TITLE
Remove unmaintained snap package

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,17 +14,6 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v2
-      - name: Set up Snapcraft
-        run: |
-          sudo apt-get update
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
-          mkdir -p $HOME/.cache/snapcraft/download
-          mkdir -p $HOME/.cache/snapcraft/stage-packages
-      - name: Login Snapcraft
-        env:
-          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
-        if: env.SNAPCRAFT_LOGIN != null
-        run: snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,18 +61,6 @@ brews:
     description: "Disk Usage/Free Utility"
     # skip_upload: true
 
-snapcrafts:
-  - name: duf-utility
-    publish: true
-    summary: duf
-    description: |
-      Disk Usage/Free Utility
-
-    grade: stable
-    confinement: classic
-    license: MIT
-    base: core20
-
 signs:
   - artifacts: checksum
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 - Arch Linux: `pacman -S duf`
 - Nix: `nix-env -iA nixpkgs.duf`
 - Void Linux: `xbps-install -S duf`
-- Snap: `sudo snap install duf-utility` ([snapcraft.io](https://snapcraft.io/duf-utility))
 - [Packages](https://github.com/muesli/duf/releases) in Alpine, Debian & RPM formats
 
 #### BSD


### PR DESCRIPTION
The snap package is currently unmaintained and not working correctly. The required permission for a tool like `duf` doesn't exist in snap yet, and Canonical refused turning `duf` into a classic snap, which would work around this issue. Maybe in the future.