### PR TITLE
Update go-wilcard lib #156

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,10 @@ module github.com/muesli/duf
 go 1.15
 
 require (
-	git.iglou.eu/Imported/go-wildcard v1.0.1
+	github.com/IGLOU-EU/go-wildcard v1.0.2
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mattn/go-runewidth v0.0.13
 	github.com/muesli/termenv v0.9.0
 	golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0
 	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
 )
-
-replace git.iglou.eu/Imported/go-wildcard => github.com/IGLOU-EU/go-wildcard v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/IGLOU-EU/go-wildcard v1.0.1 h1:c+fSJUP8QxS9Fyj5LT3V+sWd8XaDdsuMRBpCScrnKSA=
-github.com/IGLOU-EU/go-wildcard v1.0.1/go.mod h1:ni+caI7lkwXjCtYujDMsXUfNLKnvnyKeM5P03eaPBxA=
+github.com/IGLOU-EU/go-wildcard v1.0.2 h1:XLitXLt1Zt5ho4TZuqDbUSn8NDpu6bkLg25kJQ+YEXA=
+github.com/IGLOU-EU/go-wildcard v1.0.2/go.mod h1:/qeV4QLmydCbwH0UMQJmXDryrFKJknWi/jjO8IiuQfY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	wildcard "git.iglou.eu/Imported/go-wildcard"
+	wildcard "github.com/IGLOU-EU/go-wildcard"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/muesli/termenv"
 	terminal "golang.org/x/term"


### PR DESCRIPTION
After thinking about, adding the library internally would not be clean.
So I migrated it to GitHub, like proposed.

That's ok for you @muesli ?

Revision here:
https://github.com/IGLOU-EU/go-wildcard/releases/tag/v1.0.2