### PR TITLE
Add 'ansi' theme that uses the terminal's native 4-bit ANSI colors

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ var (
 	output   = flag.String("output", "", "output fields: "+strings.Join(columnIDs(), ", "))
 	sortBy   = flag.String("sort", "mountpoint", "sort output by: "+strings.Join(columnIDs(), ", "))
 	width    = flag.Uint("width", 0, "max output width")
-	themeOpt = flag.String("theme", defaultThemeName(), "color themes: dark, light")
+	themeOpt = flag.String("theme", defaultThemeName(), "color themes: dark, light, ansi")
 	styleOpt = flag.String("style", defaultStyleName(), "style: unicode, ascii")
 
 	availThreshold = flag.String("avail-threshold", "10G,1G", "specifies the coloring threshold (yellow, red) of the avail column, must be integer with optional SI prefixes")
@@ -179,6 +179,14 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+	if term == termenv.ANSI {
+		// enforce ANSI theme for limited color support
+		theme, err = loadTheme("ansi")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	}
 
 	// validate style

--- a/themes.go
+++ b/themes.go
@@ -46,6 +46,16 @@ func loadTheme(theme string) (Theme, error) {
 		colorCyan:    term.Color("#0087FF"),
 	}
 
+	themes["ansi"] = Theme{
+		colorRed:     term.Color("9"),
+		colorYellow:  term.Color("11"),
+		colorGreen:   term.Color("10"),
+		colorBlue:    term.Color("12"),
+		colorGray:    term.Color("7"),
+		colorMagenta: term.Color("13"),
+		colorCyan:    term.Color("8"),
+	}
+
 	if _, ok := themes[theme]; !ok {
 		return Theme{}, fmt.Errorf("Unknown theme: %s", theme)
 	}


### PR DESCRIPTION
This theme will use the terminal's default 4-bit ANSI colors.

```bash
$ duf -theme ansi
```

Fixes #158.