### PR TITLE
Add option '--combine' to display all mount points in one table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ If you want to list everything (including pseudo, duplicate, inaccessible file s
 
     duf --all
 
+If you want to display all mount points in just one table:
+
+    duf --combine
+
 ### Filtering
 
 You can show and hide specific tables:

--- a/duf.1
+++ b/duf.1
@@ -38,6 +38,8 @@ hide specific mount points, separated with commas (supports wildcards)
 .TP
 \fB-inodes\fP
 list inode information instead of block usage
+\fB-combine\fP
+Display all mount points in one table
 .TP
 \fB-json\fP
 output all devices in JSON format

--- a/groups.go
+++ b/groups.go
@@ -102,16 +102,9 @@ func renderTables(m []Mount, filters FilterOptions, opts TableOptions) {
 		}
 
 		t := deviceType(v)
-		deviceMounts[t] = append(deviceMounts[t], v)
-	}
-
-	// print tables
-	for _, devType := range groups {
-		mounts := deviceMounts[devType]
-
 		shouldPrint := *all
-		if !shouldPrint {
-			switch devType {
+		if !shouldPrint || *all == true {
+			switch t {
 			case localDevice:
 				shouldPrint = (hasOnlyDevices && onlyLocal) || (!hasOnlyDevices && !hideLocal)
 			case networkDevice:
@@ -121,9 +114,23 @@ func renderTables(m []Mount, filters FilterOptions, opts TableOptions) {
 			case specialDevice:
 				shouldPrint = (hasOnlyDevices && onlySpecial) || (!hasOnlyDevices && !hideSpecial)
 			}
+			if shouldPrint {
+				if *combinedTable {
+					t = "combined"
+				}
+				deviceMounts[t] = append(deviceMounts[t], v)
+			}
 		}
 
-		if shouldPrint {
+	}
+
+	if *combinedTable {
+		// print combined table
+		printTable("total", deviceMounts["combined"], opts)
+	} else {
+		// print tables
+		for _, devType := range groups {
+			mounts := deviceMounts[devType]
 			printTable(devType, mounts, opts)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ var (
 	themeOpt = flag.String("theme", defaultThemeName(), "color themes: dark, light, ansi")
 	styleOpt = flag.String("style", defaultStyleName(), "style: unicode, ascii")
 
+	combinedTable = flag.Bool("combine", false, "display only one table for all mount points")
+
 	availThreshold = flag.String("avail-threshold", "10G,1G", "specifies the coloring threshold (yellow, red) of the avail column, must be integer with optional SI prefixes")
 	usageThreshold = flag.String("usage-threshold", "0.5,0.9", "specifies the coloring threshold (yellow, red) of the usage bars as a floating point number from 0 to 1")
 
@@ -308,8 +310,9 @@ func main() {
 
 	// print tables
 	renderTables(m, filters, TableOptions{
-		Columns: columns,
-		SortBy:  sortCol,
-		Style:   style,
+		Columns:       columns,
+		SortBy:        sortCol,
+		Style:         style,
+		combinedTable: *combinedTable,
 	})
 }

--- a/man.go
+++ b/man.go
@@ -61,6 +61,10 @@ List inode information instead of block usage:
 
   $ duf --inodes
 
+Display all mount points in one table:
+
+  $ duf --combine
+
 If duf doesn't detect your terminal's colors correctly, you can set a theme:
 
   $ duf --theme light

--- a/table.go
+++ b/table.go
@@ -14,9 +14,10 @@ import (
 
 // TableOptions contains all options for the table.
 type TableOptions struct {
-	Columns []int
-	SortBy  int
-	Style   table.Style
+	Columns       []int
+	SortBy        int
+	Style         table.Style
+	combinedTable bool
 }
 
 // Column defines a column.


### PR DESCRIPTION
I have added an additional option to display all mount points in one unified (combined) table.

Screenshot:
![Screenshot--2022-12-15--10-55](https://user-images.githubusercontent.com/1492142/207829688-3d34b7d2-ea0e-41d2-bba5-93625efd9f77.png)

PS: This is my very first PR in Go language. Hope You like it.
