### PR TITLE
Reference the correct Debian version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 
 #### Linux
 - Arch Linux: `pacman -S duf`
-- Ubuntu 22.04 / Debian unstable: `apt install duf`
+- Ubuntu 22.04 / Debian 12: `apt install duf`
 - Nix: `nix-env -iA nixpkgs.duf`
 - Void Linux: `xbps-install -S duf`
 - Gentoo Linux: `emerge sys-fs/duf`


### PR DESCRIPTION
The most recent Debian stable is Bookworm (12) which seems to have `duf` readily available in the package registry: https://packages.debian.org/stable/utils/duf