### PR TITLE
Removed ascii degrading from 'defaultStyleName'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/IGLOU-EU/go-wildcard v1.0.3
 	github.com/jedib0t/go-pretty/v6 v6.4.6
-	github.com/mattn/go-runewidth v0.0.14
 	github.com/muesli/mango v0.2.0
 	github.com/muesli/roff v0.1.0
 	github.com/muesli/termenv v0.15.1
@@ -17,5 +16,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 )

--- a/style.go
+++ b/style.go
@@ -1,15 +1,5 @@
 package main
 
-import "github.com/mattn/go-runewidth"
-
 func defaultStyleName() string {
-	/*
-		Due to a bug in github.com/mattn/go-runewidth v0.0.9, the width of unicode rune(such as '╭') could not be correctly
-		calculated.	Degrade to ascii to prevent broken table structure. Remove this once the bug is fixed.
-	*/
-	if runewidth.RuneWidth('╭') > 1 {
-		return "ascii"
-	}
-
 	return "unicode"
 }


### PR DESCRIPTION
I tested and it seems that it can be removed:
```
if runewidth.RuneWidth('╭') > 1 {
	return "ascii"
}
```
