### PR TITLE
enforce ANSI/light/dark theme for limited color support

### DIFF
--- a/main.go
+++ b/main.go
@@ -184,8 +184,8 @@ func main() {
 		os.Exit(1)
 	}
 	if env == termenv.ANSI {
-		// enforce ANSI theme for limited color support
-		theme, err = loadTheme("ansi")
+		// enforce ANSI/light/dark theme for limited color support
+		theme, err = loadTheme(*themeOpt)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)


### PR DESCRIPTION

 ##  What does this PR do ?
      This PR enforces  enforce ANSI/light/dark theme for limited color support
      
  Fixes #262 
  
  
<img width="1710" alt="Screenshot 2024-10-06 at 9 17 37 PM" src="https://github.com/user-attachments/assets/a13c6c84-dd94-45bb-bfe4-d37e00a2801d">
