### PR TITLE
Added .gitignore and configuration files, updated mounts_linux.go

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/duf.iml
+++ b/.idea/duf.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/duf.iml" filepath="$PROJECT_DIR$/.idea/duf.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Recently I upgraded my wsl distro from Ubuntu 22.04 to Ubuntu 24.04. When calling duf I recognized an error: "panic: runtime error: index out of range [11] with length 11", the cause of this is a line in /proc/self/mountinfo which contains a line for "/Docker/host" which contains unescaped path info referencing C:\Prgram Files" I changed the code so that it works agoin under wsl with Ubuntu 24.04.

The mounts_linux.go file has been updated with improved handling of comments, empty lines, and Windows-style paths. A helper function was also introduced to fix unescaped spaces in Windows-style paths.

New .gitignore file has been added to the project, specifying default ignored files. Several IntelliJ IDEA configuration files have also been introduced, including module settings, VCS mappings, and project modules. These changes aim to improve the development environment setup for contributors using this specific IDE.