### PR TITLE
Fix mountinfo parsing runtime error and core dump

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -151,6 +151,8 @@ func parseMountInfoLine(line string) (int, [11]string) {
 
 			// separator found, continue parsing
 			i++
+		} else if i >= 11 {
+			break
 		}
 
 		switch i {


### PR DESCRIPTION
This prevents a panic and core dump when, for example, a mounting location has a space in it:

> 348 77 0:72 / /mnt/all rw,relatime shared:461 - overlay overlay rw,lowerdir=/mnt/mirror/.new/み　未/mnt/all:/mnt/mirror/.new/すみ　済/mnt/all,upperdir=/mnt/all,workdir=/var/spool/overlayfs

Panic:

```
$ ./duf
panic: runtime error: index out of range [11] with length 11

goroutine 1 [running]:
main.parseMountInfoLine({0xc00017c000?, 0x0?})
        /home/user/.local/git/duf/mounts_linux.go:165 +0x279
main.mounts()
        /home/user/.local/git/duf/mounts_linux.go:61 +0x145
main.main()
        /home/user/.local/git/duf/main.go:166 +0x1c5
```

Core dump:

```
$ uname -srvmo
Linux 6.13.6-200.fc41.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar  7 21:33:48 UTC 2025 x86_64 GNU/Linux
$ duf
panic: runtime error: index out of range [11] with length 11

goroutine 1 gp=0xc0000061c0 m=0 mp=0x55b4df208140 [running]:
panic({0x55b4df11cf80?, 0xc000144030?})
        /usr/lib/golang/src/runtime/panic.go:804 +0x168 fp=0xc0000ced80 sp=0xc0000cecd0 pc=0x55b4df00d148
runtime.goPanicIndex(0xb, 0xb)
        /usr/lib/golang/src/runtime/panic.go:115 +0x74 fp=0xc0000cedc0 sp=0xc0000ced80 pc=0x55b4defd7b34
main.parseMountInfoLine({0xc0000e0000?, 0x0?})
        /builddir/build/BUILD/duf-0.8.1-build/duf-0.8.1/_build/src/github.com/muesli/duf/mounts_linux.go:165 +0x279 fp=0xc0000ceee8 sp=0xc0000cedc0 pc=0x55b4df0b8819
main.mounts()
        /builddir/build/BUILD/duf-0.8.1-build/duf-0.8.1/_build/src/github.com/muesli/duf/mounts_linux.go:61 +0x145 fp=0xc0000cf5d0 sp=0xc0000ceee8 pc=0x55b4df0b78a5
main.main()
        /builddir/build/BUILD/duf-0.8.1-build/duf-0.8.1/_build/src/github.com/muesli/duf/main.go:166 +0x1c5 fp=0xc0000cff50 sp=0xc0000cf5d0 pc=0x55b4df0b6345
runtime.main()
        /usr/lib/golang/src/runtime/proc.go:272 +0x29d fp=0xc0000cffe0 sp=0xc0000cff50 pc=0x55b4defdc73d
runtime.goexit({})
        /usr/lib/golang/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc0000cffe8 sp=0xc0000cffe0 pc=0x55b4df014641

goroutine 2 gp=0xc000006c40 m=nil [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/lib/golang/src/runtime/proc.go:424 +0xce fp=0xc000064fa8 sp=0xc000064f88 pc=0x55b4df00d52e
runtime.goparkunlock(...)
        /usr/lib/golang/src/runtime/proc.go:430
runtime.forcegchelper()
        /usr/lib/golang/src/runtime/proc.go:337 +0xb8 fp=0xc000064fe0 sp=0xc000064fa8 pc=0x55b4defdca78
runtime.goexit({})
        /usr/lib/golang/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc000064fe8 sp=0xc000064fe0 pc=0x55b4df014641
created by runtime.init.8 in goroutine 1
        /usr/lib/golang/src/runtime/proc.go:325 +0x1a

goroutine 3 gp=0xc000007180 m=nil [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/lib/golang/src/runtime/proc.go:424 +0xce fp=0xc000065780 sp=0xc000065760 pc=0x55b4df00d52e
runtime.goparkunlock(...)
        /usr/lib/golang/src/runtime/proc.go:430
runtime.bgsweep(0xc000028080)
        /usr/lib/golang/src/runtime/mgcsweep.go:277 +0x94 fp=0xc0000657c8 sp=0xc000065780 pc=0x55b4defc8574
runtime.gcenable.gowrap1()
        /usr/lib/golang/src/runtime/mgc.go:203 +0x25 fp=0xc0000657e0 sp=0xc0000657c8 pc=0x55b4defbcea5
runtime.goexit({})
        /usr/lib/golang/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc0000657e8 sp=0xc0000657e0 pc=0x55b4df014641
created by runtime.gcenable in goroutine 1
        /usr/lib/golang/src/runtime/mgc.go:203 +0x66

goroutine 4 gp=0xc000007340 m=nil [GC scavenge wait]:
runtime.gopark(0xc000028080?, 0x55b4df0f1ba0?, 0x1?, 0x0?, 0xc000007340?)
        /usr/lib/golang/src/runtime/proc.go:424 +0xce fp=0xc000065f78 sp=0xc000065f58 pc=0x55b4df00d52e
runtime.goparkunlock(...)
        /usr/lib/golang/src/runtime/proc.go:430
runtime.(*scavengerState).park(0x55b4df207080)
        /usr/lib/golang/src/runtime/mgcscavenge.go:425 +0x49 fp=0xc000065fa8 sp=0xc000065f78 pc=0x55b4defc5fa9
runtime.bgscavenge(0xc000028080)
        /usr/lib/golang/src/runtime/mgcscavenge.go:653 +0x3c fp=0xc000065fc8 sp=0xc000065fa8 pc=0x55b4defc651c
runtime.gcenable.gowrap2()
        /usr/lib/golang/src/runtime/mgc.go:204 +0x25 fp=0xc000065fe0 sp=0xc000065fc8 pc=0x55b4defbce45
runtime.goexit({})
        /usr/lib/golang/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc000065fe8 sp=0xc000065fe0 pc=0x55b4df014641
created by runtime.gcenable in goroutine 1
        /usr/lib/golang/src/runtime/mgc.go:204 +0xa5

goroutine 5 gp=0xc000007c00 m=nil [finalizer wait]:
runtime.gopark(0xc000064648?, 0x55b4defb39a5?, 0xb0?, 0x1?, 0xc0000061c0?)
        /usr/lib/golang/src/runtime/proc.go:424 +0xce fp=0xc000064620 sp=0xc000064600 pc=0x55b4df00d52e
runtime.runfinq()
        /usr/lib/golang/src/runtime/mfinal.go:193 +0x107 fp=0xc0000647e0 sp=0xc000064620 pc=0x55b4defbbf27
runtime.goexit({})
        /usr/lib/golang/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc0000647e8 sp=0xc0000647e0 pc=0x55b4df014641
created by runtime.createfing in goroutine 1
        /usr/lib/golang/src/runtime/mfinal.go:163 +0x3d
中止 (コアダンプ)
```

I tested by running locally and confirming successful output.