### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 - Nix: `nix-env -iA nixpkgs.duf`
 - Void Linux: `xbps-install -S duf`
 - Gentoo Linux: `emerge sys-fs/duf`
+- with [gah](https://github.com/marverix/gah): `gah install duf`
 - [Packages](https://github.com/muesli/duf/releases) in Alpine, Debian & RPM formats
 
 #### BSD
@@ -37,6 +38,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 #### macOS
 - with [Homebrew](https://brew.sh/): `brew install duf`
 - with [MacPorts](https://www.macports.org): `sudo port selfupdate && sudo port install duf`
+- with [gah](https://github.com/marverix/gah): `gah install duf`
 
 #### Windows
 - with [Chocolatey](https://chocolatey.org/): `choco install duf`


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.