### PR TITLE
ci: deadcode linter is no longer used

### DIFF
--- a/filesystems_linux.go
+++ b/filesystems_linux.go
@@ -5,7 +5,7 @@ package main
 
 import "strings"
 
-//nolint:revive,deadcode
+//nolint:revive
 const (
 	// man statfs
 	ADFS_SUPER_MAGIC      = 0xadf5

--- a/mounts.go
+++ b/mounts.go
@@ -49,7 +49,7 @@ func unescapeFstab(path string) string {
 	return escaped
 }
 
-//nolint:deadcode,unused // used on BSD
+//nolint:unused // used on BSD
 func byteToString(orig []byte) string {
 	n := -1
 	l := -1
@@ -73,7 +73,7 @@ func byteToString(orig []byte) string {
 	return string(orig[l:n])
 }
 
-//nolint:deadcode,unused // used on OpenBSD
+//nolint:unused // used on OpenBSD
 func intToString(orig []int8) string {
 	ret := make([]byte, len(orig))
 	size := -1


### PR DESCRIPTION
deadcode has been removed from golangci-lint.