### PR TITLE
fix: include version number in tarballs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ archives:
         formats: ['zip']
     name_template: >-
       {{- .ProjectName }}_
+      {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
Include version number in generated tarballs.

FIX: #317.