### PR TITLE
fix: parse modified git tree flag correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func printVersion() {
 			case "vcs.time":
 				buildTime, _ = time.Parse(time.RFC3339, setting.Value)
 			case "vcs.modified":
-				modified = true
+				modified, _ = strconv.ParseBool(setting.Value)
 			}
 		}
 	}


### PR DESCRIPTION
We need to, uhm, actually parse the value.