### PR TITLE
optimize regex usage and improve stringToSize function

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -34,7 +34,7 @@ const (
 	// (6) optional fields: zero or more fields terminated by "-".
 	mountinfoOptionalFields = 6
 	// (7) separator between optional fields.
-	//mountinfoSeparator = 7
+	// mountinfoSeparator = 7
 	// (8) filesystem type: name of filesystem of the form.
 	mountinfoFsType = 8
 	// (9) mount source: filesystem specific information or "none".
@@ -42,6 +42,8 @@ const (
 	// (10) super options: per super block options.
 	mountinfoSuperOptions = 10
 )
+
+var statRegex = regexp.MustCompile(`^/dev/mapper/(.*)-(.*)`)
 
 // Stat returns the mountpoint's stat information.
 func (m *Mount) Stat() unix.Statfs_t {
@@ -109,8 +111,7 @@ func mounts() ([]Mount, []string, error) {
 
 		// Resolve /dev/mapper/* device names.
 		if strings.HasPrefix(d.Device, "/dev/mapper/") {
-			re := regexp.MustCompile(`^/dev/mapper/(.*)-(.*)`)
-			match := re.FindAllStringSubmatch(d.Device, -1)
+			match := statRegex.FindAllStringSubmatch(d.Device, -1)
 			if len(match) > 0 && len(match[0]) == 3 {
 				d.Device = filepath.Join("/dev", match[0][1], match[0][2])
 			}

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,63 @@
+package main
+
+import "testing"
+
+func Test_stringToSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    uint64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"42", 42, false},
+
+		{"1K", 1 << 10, false},
+		{"2M", 2 << 20, false},
+		{"3G", 3 << 30, false},
+		{"4T", 4 << 40, false},
+		{"5P", 5 << 50, false},
+		{"6E", 6 << 60, false},
+
+		{"", 0, true},
+		{"abc", 0, true},
+		{"10Z", 0, true},
+		{"-5", 0, true},
+		{"18446744073709551615", ^uint64(0), false},
+
+		{" 10K", 0, true},
+		{"10K ", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stringToSize(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("stringToSize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("stringToSize() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkStringToSize(b *testing.B) {
+	cases := []string{
+		"42",
+		"1K",
+		"128M",
+		"512G",
+		"2T",
+		"5P",
+		"6E",
+		"invalid",
+	}
+
+	for _, input := range cases {
+		b.Run(input, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = stringToSize(input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Move statRegex to package level to avoid recompilation
- Refactor stringToSize with early returns and lookup table
- Add comprehensive test cases and benchmarks for stringToSize

<img width="729" height="554" alt="image" src="https://github.com/user-attachments/assets/76ac4422-2736-42b8-9aae-5d424ccf5812" />
