### PR TITLE
Add AIX support

### DIFF
--- a/filesystems_aix.go
+++ b/filesystems_aix.go
@@ -1,0 +1,32 @@
+//go:build aix
+// +build aix
+
+package main
+
+// isFuseFs reports whether the mount is a FUSE filesystem.
+func isFuseFs(m Mount) bool {
+	return false // AIX doesn't have FUSE
+}
+
+// isNetworkFs reports whether the mount is a network filesystem.
+func isNetworkFs(m Mount) bool {
+	switch m.Fstype {
+	case "nfs", "nfs3", "nfs4", "cifs", "smbfs", "afs":
+		return true
+	}
+	return false
+}
+
+// isSpecialFs reports whether the mount is a special filesystem.
+func isSpecialFs(m Mount) bool {
+	switch m.Fstype {
+	case "procfs", "namefs", "sfs", "cdrom":
+		return true
+	}
+	return false
+}
+
+// isHiddenFs reports whether the mount is a hidden filesystem.
+func isHiddenFs(m Mount) bool {
+	return false
+}

--- a/mounts_aix.go
+++ b/mounts_aix.go
@@ -1,0 +1,95 @@
+//go:build aix
+// +build aix
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Stat returns the mountpoint's stat information.
+func (m *Mount) Stat() unix.Statfs_t {
+	return m.Metadata.(unix.Statfs_t)
+}
+
+// mounts returns all mounted filesystems from AIX.
+// AIX mount output format (after header):
+//   /dev/hd4  /  jfs2  Dec 30 22:15 rw,log=/dev/hd8
+// Fields: device mountpoint fstype month day time options
+func mounts() ([]Mount, []string, error) {
+	var ret []Mount
+	var warnings []string
+
+	cmd := exec.Command("mount")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("running mount command: %w", err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// Skip header lines (first 2 lines)
+		if lineNum <= 2 {
+			continue
+		}
+
+		// Skip empty lines
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+
+		// Fields: device mountpoint fstype month day time [options]
+		device := fields[0]
+		mountPoint := fields[1]
+		fstype := fields[2]
+		// fields[3], fields[4], fields[5] are date/time
+		opts := ""
+		if len(fields) >= 7 {
+			opts = fields[6]
+		}
+
+		var stat unix.Statfs_t
+		err := unix.Statfs(mountPoint, &stat)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", mountPoint, err))
+			continue
+		}
+
+		d := Mount{
+			Device:     device,
+			Mountpoint: mountPoint,
+			Fstype:     fstype,
+			Type:       fstype,
+			Opts:       opts,
+			Metadata:   stat,
+			Total:      uint64(stat.Blocks) * uint64(stat.Bsize),
+			Free:       uint64(stat.Bavail) * uint64(stat.Bsize),
+			Used:       (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(stat.Bsize),
+			Inodes:     stat.Files,
+			InodesFree: stat.Ffree,
+			InodesUsed: stat.Files - stat.Ffree,
+			Blocks:     uint64(stat.Blocks),
+			BlockSize:  uint64(stat.Bsize),
+		}
+		d.DeviceType = deviceType(d)
+
+		ret = append(ret, d)
+	}
+
+	return ret, warnings, nil
+}


### PR DESCRIPTION
# Add AIX support

## Summary

This PR adds support for IBM AIX operating system.

## Changes

- `filesystems_aix.go`: AIX-specific filesystem type detection
- `mounts_aix.go`: Mount point enumeration using AIX's `mount` command and `statfs` syscall

## Implementation Notes

AIX doesn't have `/proc/self/mountinfo` like Linux or `Getfsstat` like BSD, so the implementation parses the output of the `mount` command and uses `unix.Statfs` for filesystem statistics.

### Filesystem Types

- **Network**: nfs, nfs3, nfs4, cifs, smbfs, afs
- **Special**: procfs, namefs, sfs, cdrom
- **FUSE**: Not supported on AIX (returns false)

## Testing

Tested on AIX 7.3 TL4 (POWER9):

```
$ ./duf
╭──────────────────────────────────────────────────────────────────────────────╮
│ 9 local devices                                                              │
├──────────────────┬────────┬────────┬────────┬────────┬───────┬───────────────┤
│ MOUNTED ON       │   SIZE │   USED │  AVAIL │  USE%  │ TYPE  │ FILESYSTEM    │
├──────────────────┼────────┼────────┼────────┼────────┼───────┼───────────────┤
│ /                │  12.1G │   3.0G │   9.1G │  24.5% │ jfs2  │ /dev/hd4      │
│ /usr             │   7.8G │   2.7G │   5.1G │  34.4% │ jfs2  │ /dev/hd2      │
│ /var             │  15.2G │ 343.4M │  14.9G │   2.2% │ jfs2  │ /dev/hd9var   │
│ /tmp             │  40.1G │   7.1G │  33.0G │  17.8% │ jfs2  │ /dev/hd3      │
│ /home            │ 128.0M │ 772.0K │ 127.2M │   0.6% │ jfs2  │ /dev/hd1      │
│ /opt             │  17.1G │   9.7G │   7.4G │  56.9% │ jfs2  │ /dev/hd10opt  │
...
```

## Build

```bash
GOOS=aix GOARCH=ppc64 go build
```

## Notes

- Requires Go 1.21+ (official Go, not gccgo)
- Uses `golang.org/x/sys/unix` which already has full AIX support
- Color output works correctly via termenv (AIX support added in v0.16.0)

---

Contributed by [LibrePower](https://librepower.org) - Open source tools for IBM Power systems.