### PR TITLE
fix: don't call statfs on autofs mounts

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -79,14 +79,22 @@ func mounts() ([]Mount, []string, error) {
 		device := fields[mountinfoMountSource]
 
 		var stat unix.Statfs_t
-		err := unix.Statfs(mountPoint, &stat)
-		if err != nil {
-			if err != os.ErrPermission {
-				warnings = append(warnings, fmt.Sprintf("%s: %s", mountPoint, err))
-				continue
+		if fstype == "autofs" {
+			// Avoid calling statfs on autofs mount points as this triggers the
+			// automount.
+			stat = unix.Statfs_t{
+				Type: AUTOFS_SUPER_MAGIC,
 			}
+		} else {
+			err := unix.Statfs(mountPoint, &stat)
+			if err != nil {
+				if err != os.ErrPermission {
+					warnings = append(warnings, fmt.Sprintf("%s: %s", mountPoint, err))
+					continue
+				}
 
-			stat = unix.Statfs_t{}
+				stat = unix.Statfs_t{}
+			}
 		}
 
 		d := Mount{


### PR DESCRIPTION
Calling statfs on autofs mounts will trigger a filesystem mount. This can hang duf (especially when mounting network filesystems) and erroneously assign the statfs results of the mounted filesystem to the autofs entry.

I also set the `Statfs_t.Type` field manually, so that autofs is correctly identified as a special filesystem.

Fixes #250 

Feels a bit hacky but I can't think of a better solution.