### PR TITLE
Add option '--reverse' to reverse sort order

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 
 	output   = flag.String("output", "", "output fields: "+strings.Join(columnIDs(), ", "))
 	sortBy   = flag.String("sort", "mountpoint", "sort output by: "+strings.Join(columnIDs(), ", "))
+	reverse  = flag.Bool("reverse", false, "reverse sort order")
 	width    = flag.Uint("width", 0, "max output width")
 	themeOpt = flag.String("theme", defaultThemeName(), "color themes: dark, light, ansi")
 	styleOpt = flag.String("style", defaultStyleName(), "style: unicode, ascii")
@@ -356,6 +357,7 @@ func main() {
 	renderTables(m, filters, TableOptions{
 		Columns:   columns,
 		SortBy:    sortCol,
+		Reverse:   *reverse,
 		Style:     style,
 		StyleName: *styleOpt,
 	})

--- a/table.go
+++ b/table.go
@@ -17,6 +17,7 @@ import (
 type TableOptions struct {
 	Columns   []int
 	SortBy    int
+	Reverse   bool
 	Style     table.Style
 	StyleName string
 }
@@ -432,8 +433,15 @@ func printTable(title string, m []Mount, opts TableOptions) {
 
 	// tab.AppendFooter(table.Row{fmt.Sprintf("%d %s", tab.Length(), title)})
 	sortMode := table.Asc
-	if opts.SortBy >= 12 {
-		sortMode = table.AscNumeric
+	if opts.Reverse {
+		sortMode = table.Dsc
+		if opts.SortBy >= 12 {
+			sortMode = table.DscNumeric
+		}
+	} else {
+		if opts.SortBy >= 12 {
+			sortMode = table.AscNumeric
+		}
 	}
 
 	tab.SortBy([]table.SortBy{{Number: opts.SortBy, Mode: sortMode}})


### PR DESCRIPTION
I'd prefer to have the largest devices listed first, so I added a `--reverse` option.

Example sorting string values Z-A:
<img width="1268" height="460" alt="image" src="https://github.com/user-attachments/assets/a349bd88-acbb-4e7f-a362-71fbe59c5b1e" />

Example sorting numeric values largest first:
<img width="1274" height="433" alt="image" src="https://github.com/user-attachments/assets/5459816b-d6d9-4d57-a3ef-58457a251179" />
