### PR TITLE
docs: fix README capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Disk Usage/Free Utility (Linux, BSD, macOS & Windows)
 
 #### Windows
 - with [Chocolatey](https://chocolatey.org/): `choco install duf`
-- with [scoop](https://scoop.sh/): `scoop install duf`
+- with [Scoop](https://scoop.sh/): `scoop install duf`
 
 #### Android
 - Android (via termux): `pkg install duf`


### PR DESCRIPTION
## Summary
- Capitalize Scoop in the Windows installation instructions.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/muesli/duf/blob/master/README.md

## Validation/testing
- Not run (docs change only)