### PR TITLE
docs: fix WSL2 mount comment wording

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -205,7 +205,7 @@ func parseMountInfoLine(line string) (int, [11]string) {
 		}
 
 		if i == mountinfoSuperOptions {
-			// join tokens with spaces for WSL2 path=... they are splitted around spaces.
+			// join tokens with spaces for WSL2 path=... they are split around spaces.
 			fields[i] = strings.TrimSpace(fields[i] + " " + f)
 			sawSup = true
 			continue


### PR DESCRIPTION
## Summary
- fix the wording in a Linux mount parsing comment.

## Related issue
- N/A; trivial docs/comment fix.

## Guideline alignment
- No CONTRIBUTING or PR template was present; kept this to a one-file comment-only change with no behavior change.

## Validation
- Not run; docs/comment-only change.
