### PR TITLE
fix: correctly resolve /dev/mapper paths with hyphens in VG/LV names

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -108,18 +107,35 @@ func mounts() ([]Mount, []string, error) {
 		d.DeviceType = deviceType(d)
 
 		// Resolve /dev/mapper/* device names.
-		if strings.HasPrefix(d.Device, "/dev/mapper/") {
-			re := regexp.MustCompile(`^/dev/mapper/(.*)-(.*)`)
-			match := re.FindAllStringSubmatch(d.Device, -1)
-			if len(match) > 0 && len(match[0]) == 3 {
-				d.Device = filepath.Join("/dev", match[0][1], match[0][2])
-			}
-		}
+		d.Device = resolveMapperDevice(d.Device)
 
 		ret = append(ret, d)
 	}
 
 	return ret, warnings, nil
+}
+
+// resolveMapperDevice resolves /dev/mapper/* device names to /dev/<VG>/<LV>.
+// LVM escapes hyphens in VG/LV names by doubling them (--).
+// A single hyphen separates the VG name from the LV name.
+func resolveMapperDevice(device string) string {
+	if !strings.HasPrefix(device, "/dev/mapper/") {
+		return device
+	}
+
+	name := strings.TrimPrefix(device, "/dev/mapper/")
+	// Replace escaped double-hyphens with a placeholder so we can
+	// split on the real single-hyphen separator.
+	const placeholder = "\x00"
+	escaped := strings.ReplaceAll(name, "--", placeholder)
+	parts := strings.SplitN(escaped, "-", 2)
+	if len(parts) != 2 {
+		return device
+	}
+
+	vg := strings.ReplaceAll(parts[0], placeholder, "-")
+	lv := strings.ReplaceAll(parts[1], placeholder, "-")
+	return filepath.Join("/dev", vg, lv)
 }
 
 // splitMountInfoFields splits a mountinfo line into its fields.

--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -135,6 +135,9 @@ func resolveMapperDevice(device string) string {
 
 	vg := strings.ReplaceAll(parts[0], placeholder, "-")
 	lv := strings.ReplaceAll(parts[1], placeholder, "-")
+	if vg == "" || lv == "" {
+		return device
+	}
 	return filepath.Join("/dev", vg, lv)
 }
 

--- a/mounts_linux_test.go
+++ b/mounts_linux_test.go
@@ -33,6 +33,10 @@ func TestResolveMapperDevice(t *testing.T) {
 
 		// No separator (single partition name) — returned unchanged.
 		{input: "/dev/mapper/control", expected: "/dev/mapper/control"},
+
+		// Degenerate: empty VG or LV — returned unchanged.
+		{input: "/dev/mapper/-lv", expected: "/dev/mapper/-lv"},
+		{input: "/dev/mapper/vg-", expected: "/dev/mapper/vg-"},
 	}
 
 	for _, tc := range tt {

--- a/mounts_linux_test.go
+++ b/mounts_linux_test.go
@@ -8,6 +8,41 @@ import (
 	"testing"
 )
 
+func TestResolveMapperDevice(t *testing.T) {
+	var tt = []struct {
+		input    string
+		expected string
+	}{
+		// Non-mapper devices are returned unchanged.
+		{input: "/dev/sda1", expected: "/dev/sda1"},
+		{input: "/dev/nvme0n1p1", expected: "/dev/nvme0n1p1"},
+
+		// Simple VG-LV (no hyphens in names).
+		{input: "/dev/mapper/vg0-root", expected: "/dev/vg0/root"},
+		{input: "/dev/mapper/vg0-swap", expected: "/dev/vg0/swap"},
+
+		// Hyphens in LV name (escaped as --).
+		{input: "/dev/mapper/vg0-var--log", expected: "/dev/vg0/var-log"},
+		{input: "/dev/mapper/vg0-var--log--audit", expected: "/dev/vg0/var-log-audit"},
+
+		// Hyphens in VG name (escaped as --).
+		{input: "/dev/mapper/my--vg-root", expected: "/dev/my-vg/root"},
+
+		// Hyphens in both VG and LV names.
+		{input: "/dev/mapper/my--vg-my--lv", expected: "/dev/my-vg/my-lv"},
+
+		// No separator (single partition name) — returned unchanged.
+		{input: "/dev/mapper/control", expected: "/dev/mapper/control"},
+	}
+
+	for _, tc := range tt {
+		actual := resolveMapperDevice(tc.input)
+		if actual != tc.expected {
+			t.Errorf("resolveMapperDevice(%q) == %q, expected %q", tc.input, actual, tc.expected)
+		}
+	}
+}
+
 func TestGetFields(t *testing.T) {
 	var tt = []struct {
 		input    string


### PR DESCRIPTION
## Summary

Fixes #329 — `/dev/mapper/` paths containing hyphens in VG or LV names were incorrectly resolved.

LVM escapes hyphens in volume group and logical volume names by doubling them (`--`) in `/dev/mapper/` paths. A single hyphen separates the VG name from the LV name. The previous greedy regex `(.*)-(.*)`  split on the **last** hyphen, which broke paths like:

| Input | Before (wrong) | After (correct) |
|---|---|---|
| `/dev/mapper/vg0-var--log` | `/dev/vg0-var-/log` | `/dev/vg0/var-log` |
| `/dev/mapper/my--vg-my--lv` | `/dev/my--vg-my-/lv` | `/dev/my-vg/my-lv` |

### Approach

Replaced the regex with a string-based approach:
1. Replace escaped `--` with a null-byte placeholder
2. Split on the first single `-` (the real VG–LV separator)
3. Restore `-` from placeholders in both captured parts

This also removes the `regexp` import (no longer needed).

### Extracted helper

The logic is now in a standalone `resolveMapperDevice()` function with dedicated test cases covering:
- Simple VG-LV names (no hyphens)
- Hyphens in LV name only
- Hyphens in VG name only
- Hyphens in both VG and LV names
- Non-mapper devices (returned unchanged)
- Names without a separator (returned unchanged)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] `go test ./...` passes on Linux CI (tests are `//go:build linux`)