### PR TITLE
fix: parse escaped device mapper names

### DIFF
--- a/mounts_linux.go
+++ b/mounts_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -108,18 +107,46 @@ func mounts() ([]Mount, []string, error) {
 		d.DeviceType = deviceType(d)
 
 		// Resolve /dev/mapper/* device names.
-		if strings.HasPrefix(d.Device, "/dev/mapper/") {
-			re := regexp.MustCompile(`^/dev/mapper/(.*)-(.*)`)
-			match := re.FindAllStringSubmatch(d.Device, -1)
-			if len(match) > 0 && len(match[0]) == 3 {
-				d.Device = filepath.Join("/dev", match[0][1], match[0][2])
-			}
-		}
+		d.Device = resolveMapperDevice(d.Device)
 
 		ret = append(ret, d)
 	}
 
 	return ret, warnings, nil
+}
+
+// resolveMapperDevice converts device-mapper's escaped VG-LV naming back to
+// the conventional /dev/<volume-group>/<logical-volume> path.
+func resolveMapperDevice(device string) string {
+	const prefix = "/dev/mapper/"
+	if !strings.HasPrefix(device, prefix) {
+		return device
+	}
+
+	name := strings.TrimPrefix(device, prefix)
+	var vg, lv strings.Builder
+	part := &vg
+	for i := 0; i < len(name); i++ {
+		if name[i] != '-' {
+			part.WriteByte(name[i])
+			continue
+		}
+		if i+1 < len(name) && name[i+1] == '-' {
+			part.WriteByte('-')
+			i++
+			continue
+		}
+		if part == &vg {
+			part = &lv
+			continue
+		}
+		part.WriteByte('-')
+	}
+
+	if vg.Len() == 0 || lv.Len() == 0 {
+		return device
+	}
+	return filepath.Join("/dev", vg.String(), lv.String())
 }
 
 // splitMountInfoFields splits a mountinfo line into its fields.

--- a/mounts_linux_test.go
+++ b/mounts_linux_test.go
@@ -8,6 +8,38 @@ import (
 	"testing"
 )
 
+func TestResolveMapperDevice(t *testing.T) {
+	tests := map[string]struct {
+		device string
+		want   string
+	}{
+		"logical volume hyphen": {
+			device: "/dev/mapper/vg-var--log",
+			want:   "/dev/vg/var-log",
+		},
+		"volume group and logical volume hyphens": {
+			device: "/dev/mapper/vg--name-lv--name",
+			want:   "/dev/vg-name/lv-name",
+		},
+		"non mapper device": {
+			device: "/dev/sda1",
+			want:   "/dev/sda1",
+		},
+		"mapper name without separator": {
+			device: "/dev/mapper/volume",
+			want:   "/dev/mapper/volume",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := resolveMapperDevice(tt.device); got != tt.want {
+				t.Fatalf("resolveMapperDevice(%q) = %q, want %q", tt.device, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetFields(t *testing.T) {
 	var tt = []struct {
 		input    string


### PR DESCRIPTION
## Summary

- decode device-mapper's doubled-hyphen escaping when displaying LVM volume-group and logical-volume paths
- retain non-mapper devices and malformed mapper names unchanged
- add Linux regression coverage for hyphens in both volume-group and logical-volume names

## Root cause

The existing greedy regular expression split `/dev/mapper/<vg>-<lv>` at the wrong hyphen when an LVM name contained an escaped `--`. For example, `vg-var--log` was shown as `/dev/vg-var-/log` rather than `/dev/vg/var-log`.

## Validation

- `go test ./...` on Windows (build validation)
- Linux cross-compiled test binary executed under WSL: `TestResolveMapperDevice`
- `git diff --check`

Fixes #329
