### PR TITLE
Add option to combine output tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Wildcards inside quotes work:
 
     duf --only-mp '/sys/*,/dev/*'
 
+By default, duf renders a separate table per device group (local, network,
+fuse, ...). Combine them into a single table with:
+
+    duf --combine
+
 ### Display options
 
 Sort the output:

--- a/duf.1
+++ b/duf.1
@@ -27,6 +27,9 @@ include pseudo, duplicate, inaccessible file systems
 \fB--avail-threshold\fP
 specifies the coloring threshold (yellow, red) of the avail column, must be integer with optional SI prefixes
 .TP
+\fB--combine\fP
+combine all device groups into a single table
+.TP
 \fB--hide\fP
 hide specific devices, separated with commas: local, network, fuse, special, loops, binds
 .TP

--- a/groups.go
+++ b/groups.go
@@ -105,10 +105,8 @@ func renderTables(m []Mount, filters FilterOptions, opts TableOptions) {
 		deviceMounts[t] = append(deviceMounts[t], v)
 	}
 
-	// print tables
-	for _, devType := range groups {
-		mounts := deviceMounts[devType]
-
+	// determine which groups should be printed
+	shouldPrintGroup := func(devType string) bool {
 		shouldPrint := *all
 		if !shouldPrint {
 			switch devType {
@@ -122,9 +120,25 @@ func renderTables(m []Mount, filters FilterOptions, opts TableOptions) {
 				shouldPrint = (hasOnlyDevices && onlySpecial) || (!hasOnlyDevices && !hideSpecial)
 			}
 		}
+		return shouldPrint
+	}
 
-		if shouldPrint {
-			printTable(devType, mounts, opts)
+	// combine all visible groups into a single table
+	if opts.Combine {
+		var combined []Mount
+		for _, devType := range groups {
+			if shouldPrintGroup(devType) {
+				combined = append(combined, deviceMounts[devType]...)
+			}
+		}
+		printTable("", combined, opts)
+		return
+	}
+
+	// print tables
+	for _, devType := range groups {
+		if shouldPrintGroup(devType) {
+			printTable(devType, deviceMounts[devType], opts)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	onlyFs      = flag.String("only-fs", "", "only specific filesystems, separated with commas")
 	onlyMp      = flag.String("only-mp", "", "only specific mount points, separated with commas (supports wildcards)")
 
+	combine  = flag.Bool("combine", false, "combine all device groups into a single table")
 	output   = flag.String("output", "", "output fields: "+strings.Join(columnIDs(), ", "))
 	sortBy   = flag.String("sort", "mountpoint", "sort output by: "+strings.Join(columnIDs(), ", "))
 	width    = flag.Uint("width", 0, "max output width")
@@ -358,5 +359,6 @@ func main() {
 		SortBy:    sortCol,
 		Style:     style,
 		StyleName: *styleOpt,
+		Combine:   *combine,
 	})
 }

--- a/table.go
+++ b/table.go
@@ -19,6 +19,7 @@ type TableOptions struct {
 	SortBy    int
 	Style     table.Style
 	StyleName string
+	Combine   bool
 }
 
 // Column defines a column.
@@ -428,7 +429,11 @@ func printTable(title string, m []Mount, opts TableOptions) {
 	if tab.Length() > 1 {
 		suffix = "devices"
 	}
-	tab.SetTitle("%d %s %s", tab.Length(), title, suffix)
+	if title == "" {
+		tab.SetTitle("%d %s", tab.Length(), suffix)
+	} else {
+		tab.SetTitle("%d %s %s", tab.Length(), title, suffix)
+	}
 
 	// tab.AppendFooter(table.Row{fmt.Sprintf("%d %s", tab.Length(), title)})
 	sortMode := table.Asc


### PR DESCRIPTION
This change introduces the command-line option --combine. When specified, all device groups are rendered in a single output table instead of separate tables per group.

This does not affect JSON output.